### PR TITLE
Ukrainian translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ below. The card follows your dashboard's light or dark theme.
   `outdoor`, and `fridge` — or from your own profile in YAML
 - Rooms whose sensor is briefly unavailable stay on the card as `--` chips you
   can still tap
-- Translated into 14 languages, following your Home Assistant language setting
+- Translated into 15 languages, following your Home Assistant language setting
 - Plenty of optional YAML for views, bands, markers, footers, chips, the
   carousel, and tap/hold actions — see [Configuration](#configuration)
 
@@ -173,7 +173,7 @@ needs at least two rooms with values.
 | `entity_label` | automatic | Sets the small caption above the large value. `entity_label: ""` removes it. Left out, a single-room card uses that room's name, a card with only `entity` has no caption, and a card with rooms uses the translated "Home avg." caption. |
 | `icon` | automatic | Pins the header icon to an `mdi:*` icon of your choice, for example `mdi:home-thermometer`. Otherwise it follows the current value. |
 | `decimals` | mode-dependent | Sets `0`, `1`, or `2` decimal places for the large value, the room chips, the daily minimum/maximum, the spread, and the trend. Defaults: `0` for CO₂, `1` for the others. Scale and band labels stay whole numbers. |
-| `language` | `auto` | Forces one of `en`, `de`, `nl`, `fr`, `it`, `es`, `ru`, `pl`, `ko`, `ja`, `zh`, `nb`, `sv`, `lv`. `auto` follows your Home Assistant language. |
+| `language` | `auto` | Forces one of `en`, `de`, `nl`, `fr`, `it`, `es`, `ru`, `pl`, `uk`, `ko`, `ja`, `zh`, `nb`, `sv`, `lv`. `auto` follows your Home Assistant language. |
 
 #### Room-chip display
 

--- a/src/i18n/languages/uk.js
+++ b/src/i18n/languages/uk.js
@@ -1,0 +1,111 @@
+```js
+// Українські UI-рядки.
+//
+// Переклад українською для картки Home Assistant.
+// Ключі та функції повністю відповідають англійському набору.
+
+export const uk = {
+  "title.temperature": "Температура",
+  "title.humidity": "Вологість",
+  "title.co2": "CO₂",
+  "title.pm25": "PM2.5",
+
+  "level.veryHot": "Дуже спекотно",
+  "level.hot": "Спекотно",
+  "level.veryWarm": "Дуже тепло",
+  "level.warm": "Тепло",
+  "level.slightlyWarm": "Трохи тепло",
+  "level.optimal": "Оптимально",
+  "level.slightlyCool": "Трохи прохолодно",
+  "level.fresh": "Свіжо",
+  "level.cool": "Прохолодно",
+  "level.cold": "Холодно",
+  "level.veryCold": "Дуже холодно",
+
+  "level.criticallyHumid": "Критично висока вологість",
+  "level.tooHumid": "Надто висока вологість",
+  "level.veryHumid": "Дуже волого",
+  "level.humid": "Волого",
+  "level.slightlyHumid": "Трохи волого",
+  "level.slightlyDry": "Трохи сухо",
+  "level.dry": "Сухо",
+  "level.veryDry": "Дуже сухо",
+  "level.tooDry": "Надто сухо",
+  "level.criticallyDry": "Критично низька вологість",
+
+  "level.critical": "Критично",
+  "level.veryHigh": "Дуже високий",
+  "level.high": "Високий",
+  "level.elevated": "Підвищений",
+  "level.slightlyElevated": "Трохи підвищений",
+  "level.invalidReading": "Недійсне значення",
+
+  "adjective.warm": "тепло",
+  "adjective.cool": "прохолодно",
+  "adjective.humid": "волого",
+  "adjective.dry": "сухо",
+  "adjective.elevated": "підвищений",
+  "adjective.low": "низький",
+
+  "value.homeAverage": "Середнє по дому",
+  "value.tooltip": (v) => `${v.label}: ${v.value}`,
+  "value.tooltipNoLabel": (v) => `${v.value}`,
+  "value.tooltipCalculated": (v) => `${v.label}: ${v.value} · розраховано за значеннями кімнат`,
+  "value.tooltipCalculatedNoLabel": (v) => `${v.value} · розраховано за значеннями кімнат`,
+  "value.ariaOpen": "Відкрити середнє значення",
+  "status.noData": "Немає даних",
+
+  "availability.entityMissing": (v) => `Сутність ${v.entity} не знайдена.`,
+  "availability.entitiesMissing": (v) => `Налаштовані сутності ${v.count === 1 ? "кімнати" : "кімнат"} не знайдені (${v.count}): ${v.entities}.`,
+  "availability.valueUnavailable": "Значення наразі недоступне.",
+  "availability.noUsableRooms": "Наразі немає доступних значень для налаштованих кімнат.",
+  "availability.incompatible": "Налаштовані джерела використовують несумісні типи вимірювань або одиниці.",
+  "availability.roomNoData": (v) => `${v.name}: немає даних. Відкрийте деталі.`,
+  "availability.valueNoData": (v) => `${v.label}: немає даних`,
+
+  "subtitle.aboveComfort": (v) => `Середнє на ${v.diff} вище комфортного рівня · ${v.count}/${v.total} ${v.total === 1 ? "кімната" : "кімнат"}: ${v.adjective}.`,
+  "subtitle.aboveComfortNoRooms": (v) => `Середнє на ${v.diff} вище комфортного рівня.`,
+  "subtitle.belowComfort": (v) => `Середнє на ${v.diff} нижче комфортного рівня · ${v.count}/${v.total} ${v.total === 1 ? "кімната" : "кімнат"}: ${v.adjective}.`,
+  "subtitle.belowComfortNoRooms": (v) => `Середнє на ${v.diff} нижче комфортного рівня.`,
+  "subtitle.inComfortIssue": (v) => `Середнє в межах комфорту · найбільше вирізняється: ${v.name}.`,
+  "subtitle.inComfortAllGood": "Середнє в межах комфорту · у всіх кімнатах показники в цільовому діапазоні.",
+  "subtitle.inComfort": "Середнє в межах комфорту.",
+  "subtitle.missingRooms": (v) => ` ${v.count} налаштован${v.count === 1 ? "а кімната не знайдена" : "их кімнат не знайдено"}.`,
+
+  "footer.comfort": (v) => `Комфорт ${v.count}/${v.total}`,
+  "footer.spread": (v) => `Розкид ${v.value}`,
+  "footer.trend": (v) => `Тренд ${v.value}`,
+  "trend.direction.rising": "зростає",
+  "trend.direction.stable": "стабільний",
+  "trend.direction.falling": "знижується",
+  "trend.aria": (v) => `Тренд ${v.direction}: ${v.value}`,
+
+  "scale.comfortLabel": (v) => `${v.range} комфорт`,
+  "scale.comfortLabelShort": (v) => `${v.range} комфорт`,
+  "scale.optimalLabel": (v) => `${v.range} оптимально`,
+  "scale.optimalLabelShort": (v) => `${v.range} оптимально`,
+
+  "rangeScale.currentLabel": "зараз",
+  "rangeScale.currentLabelShort": "зараз",
+  "rangeScale.minLabel": "мін.",
+  "rangeScale.maxLabel": "макс.",
+  "rangeScale.footer": (v) => `Діапазон за сьогодні ${v.span} · Мін. ${v.min} (${v.minTime}) · Макс. ${v.max} (${v.maxTime})`,
+  "rangeScale.footerCompact": (v) => `Діапазон за сьогодні ${v.span} · Мін. ${v.min} · Макс. ${v.max}`,
+
+  "card.coldestRoom": "Найхолодніша кімната",
+  "card.warmestRoom": "Найтепліша кімната",
+  "card.driestRoom": "Найсухіша кімната",
+  "card.mostHumidRoom": "Найвологіша кімната",
+  "card.lowestRoom": "Найнижче значення",
+  "card.highestRoom": "Найвище значення",
+  "card.dailyMinimum": "Мінімум за день",
+  "card.dailyMaximum": "Максимум за день",
+  "card.ariaOpen": (v) => `Відкрити ${v.label}: ${v.name}`,
+
+  "room.ariaOpen": (v) => `Відкрити ${v.name}`,
+
+  "rotator.hint": "Проведіть пальцем, щоб перемикати вигляд",
+
+  "views.none": "Немає доступного вигляду.",
+};
+```

--- a/src/i18n/languages/uk.js
+++ b/src/i18n/languages/uk.js
@@ -1,6 +1,9 @@
-// Ukrainian UI strings
-// Ukrainian translation for the room climate card
-// The keys and functions correspond exactly to the English set
+// Ukrainian UI strings.
+//
+// Key set must stay identical to en.js. Ukrainian has one/few/many plural
+// categories, so count-dependent room nouns use the shared CLDR helper.
+
+import { selectPlural } from "../formatters.js";
 
 export const uk = {
   "title.temperature": "Температура",
@@ -54,21 +57,23 @@ export const uk = {
   "status.noData": "Немає даних",
 
   "availability.entityMissing": (v) => `Сутність ${v.entity} не знайдена.`,
-  "availability.entitiesMissing": (v) => `Налаштовані сутності ${v.count === 1 ? "кімнати" : "кімнат"} не знайдені (${v.count}): ${v.entities}.`,
+  "availability.entitiesMissing": (v) =>
+    `${selectPlural("uk", v.count, { one: "Налаштовану сутність кімнати не знайдено", few: "Налаштовані сутності кімнат не знайдено", many: "Налаштовані сутності кімнат не знайдено", other: "Налаштованої сутності кімнати не знайдено" })} (${v.count}): ${v.entities}.`,
   "availability.valueUnavailable": "Значення наразі недоступне.",
   "availability.noUsableRooms": "Наразі немає доступних значень для налаштованих кімнат.",
   "availability.incompatible": "Налаштовані джерела використовують несумісні типи вимірювань або одиниці.",
   "availability.roomNoData": (v) => `${v.name}: немає даних. Відкрийте деталі.`,
   "availability.valueNoData": (v) => `${v.label}: немає даних`,
 
-  "subtitle.aboveComfort": (v) => `Середнє на ${v.diff} вище комфортного рівня · ${v.count}/${v.total} ${v.total === 1 ? "кімната" : "кімнат"}: ${v.adjective}.`,
+  "subtitle.aboveComfort": (v) => `Середнє на ${v.diff} вище комфортного рівня · ${v.count}/${v.total} ${selectPlural("uk", v.total, { one: "кімната", few: "кімнати", many: "кімнат", other: "кімнати" })}: ${v.adjective}.`,
   "subtitle.aboveComfortNoRooms": (v) => `Середнє на ${v.diff} вище комфортного рівня.`,
-  "subtitle.belowComfort": (v) => `Середнє на ${v.diff} нижче комфортного рівня · ${v.count}/${v.total} ${v.total === 1 ? "кімната" : "кімнат"}: ${v.adjective}.`,
+  "subtitle.belowComfort": (v) => `Середнє на ${v.diff} нижче комфортного рівня · ${v.count}/${v.total} ${selectPlural("uk", v.total, { one: "кімната", few: "кімнати", many: "кімнат", other: "кімнати" })}: ${v.adjective}.`,
   "subtitle.belowComfortNoRooms": (v) => `Середнє на ${v.diff} нижче комфортного рівня.`,
   "subtitle.inComfortIssue": (v) => `Середнє в межах комфорту · найбільше вирізняється: ${v.name}.`,
   "subtitle.inComfortAllGood": "Середнє в межах комфорту · у всіх кімнатах показники в цільовому діапазоні.",
   "subtitle.inComfort": "Середнє в межах комфорту.",
-  "subtitle.missingRooms": (v) => ` ${v.count} налаштован${v.count === 1 ? "а кімната не знайдена" : "их кімнат не знайдено"}.`,
+  "subtitle.missingRooms": (v) =>
+    ` ${v.count} ${selectPlural("uk", v.count, { one: "налаштована кімната не знайдена", few: "налаштовані кімнати не знайдені", many: "налаштованих кімнат не знайдено", other: "налаштованої кімнати не знайдено" })}.`,
 
   "footer.comfort": (v) => `Комфорт ${v.count}/${v.total}`,
   "footer.spread": (v) => `Розкид ${v.value}`,

--- a/src/i18n/languages/uk.js
+++ b/src/i18n/languages/uk.js
@@ -1,8 +1,6 @@
-```js
-// Українські UI-рядки.
-//
-// Переклад українською для картки Home Assistant.
-// Ключі та функції повністю відповідають англійському набору.
+// Ukrainian UI strings
+// Ukrainian translation for the room climate card
+// The keys and functions correspond exactly to the English set
 
 export const uk = {
   "title.temperature": "Температура",
@@ -108,4 +106,3 @@ export const uk = {
 
   "views.none": "Немає доступного вигляду.",
 };
-```

--- a/src/i18n/locales.js
+++ b/src/i18n/locales.js
@@ -20,6 +20,7 @@ export const NUMBER_LOCALE_BY_LANGUAGE = {
   es: "es",
   ru: "ru",
   pl: "pl",
+  uk: "uk",
   ko: "ko",
   ja: "ja",
   zh: "zh",

--- a/src/i18n/registry.js
+++ b/src/i18n/registry.js
@@ -26,6 +26,7 @@ import { it } from "./languages/it.js";
 import { es } from "./languages/es.js";
 import { ru } from "./languages/ru.js";
 import { pl } from "./languages/pl.js";
+import { uk } from "./languages/uk.js";
 import { ko } from "./languages/ko.js";
 import { ja } from "./languages/ja.js";
 import { zh } from "./languages/zh.js";

--- a/src/i18n/registry.js
+++ b/src/i18n/registry.js
@@ -34,7 +34,7 @@ import { nb } from "./languages/nb.js";
 import { sv } from "./languages/sv.js";
 import { lv } from "./languages/lv.js";
 
-export const TRANSLATIONS = { en, de, nl, fr, it, es, ru, pl, ko, ja, zh, nb, sv, lv };
+export const TRANSLATIONS = { en, de, nl, fr, it, es, ru, pl, uk, ko, ja, zh, nb, sv, lv };
 
 // Load-time only, exactly as before the source split: the check has to run
 // where the assembled table first exists.

--- a/test/browser/label-geometry.spec.js
+++ b/test/browser/label-geometry.spec.js
@@ -18,7 +18,7 @@
 const { test, expect } = require("@playwright/test");
 const { gotoHarness, createCard, mkStateObj, setCardWidth } = require("../helpers/browser-helpers");
 
-const LANGUAGES = ["en", "de", "nl", "fr", "it", "es", "ru", "pl", "ko", "ja", "zh", "nb", "sv", "lv"];
+const LANGUAGES = ["en", "de", "nl", "fr", "it", "es", "ru", "pl", "uk", "ko", "ja", "zh", "nb", "sv", "lv"];
 // Widths cover the supported 280-500 px range. Below that range, some long-label
 // combinations cannot fit without exceeding the solver's layout assumptions.
 const WIDTHS = [280, 320, 380, 420, 500];

--- a/test/unit/i18n-modules.test.js
+++ b/test/unit/i18n-modules.test.js
@@ -17,7 +17,7 @@ process.env.TZ = "UTC";
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const EXPECTED_LANGUAGES = ["en", "de", "nl", "fr", "it", "es", "ru", "pl", "ko", "ja", "zh", "nb", "sv", "lv"];
+const EXPECTED_LANGUAGES = ["en", "de", "nl", "fr", "it", "es", "ru", "pl", "uk", "ko", "ja", "zh", "nb", "sv", "lv"];
 
 let locales;
 let formatters;

--- a/test/unit/i18n.test.js
+++ b/test/unit/i18n.test.js
@@ -30,7 +30,7 @@ let internals;
 let access;
 
 const CARD_SOURCE = fs.readFileSync(CARD_SOURCE_PATH, "utf8");
-const SUPPORTED_LANGUAGES = ["en", "de", "nl", "fr", "it", "es", "ru", "pl", "ko", "ja", "zh", "nb", "sv", "lv"];
+const SUPPORTED_LANGUAGES = ["en", "de", "nl", "fr", "it", "es", "ru", "pl", "uk", "ko", "ja", "zh", "nb", "sv", "lv"];
 
 test("all TRANSLATIONS language blocks stay in sync with en (the file's own load-time self-check never warns)", () => {
   const dom = new JSDOM("<!doctype html><html><body></body></html>", {
@@ -271,6 +271,37 @@ test("I18N-02: Polish room grammar follows one/few/many plural categories", () =
   for (const [count, expected] of roomExpected) {
     assert.equal(el._t("subtitle.missingRooms", { count }), expected, `rooms=${count}`);
   }
+  env.cleanup(el);
+});
+
+test("I18N-02: Ukrainian room grammar follows one/few/many plural categories", () => {
+  const el = env.createCard({ entity: "sensor.avg", language: "uk" }, hassDe);
+  const roomExpected = new Map([
+    [1, " 1 налаштована кімната не знайдена."],
+    [2, " 2 налаштовані кімнати не знайдені."],
+    [5, " 5 налаштованих кімнат не знайдено."],
+    [21, " 21 налаштована кімната не знайдена."],
+    [22, " 22 налаштовані кімнати не знайдені."],
+    [25, " 25 налаштованих кімнат не знайдено."],
+  ]);
+  for (const [count, expected] of roomExpected) {
+    assert.equal(el._t("subtitle.missingRooms", { count }), expected, `rooms=${count}`);
+  }
+  assert.match(
+    el._t("subtitle.aboveComfort", { diff: "1 °C", count: 1, total: 21, adjective: "тепло" }),
+    /1\/21 кімната: тепло\.$/,
+    "total=21 must use the singular room form"
+  );
+  assert.match(
+    el._t("subtitle.belowComfort", { diff: "1 °C", count: 2, total: 25, adjective: "прохолодно" }),
+    /2\/25 кімнат: прохолодно\.$/,
+    "total=25 must use the many room form"
+  );
+  assert.match(
+    el._t("availability.entitiesMissing", { count: 1, entities: "sensor.room" }),
+    /^Налаштовану сутність кімнати не знайдено \(1\):/,
+    "a single missing entity must use singular agreement"
+  );
   env.cleanup(el);
 });
 


### PR DESCRIPTION
Added a complete Ukrainian translation for the card UI.

Changes
Translated all UI strings from English to Ukrainian.
Preserved all translation keys and interpolation functions.
Adapted wording to sound natural in a Home Assistant interface.
Translated temperature, humidity, CO₂ and PM2.5 levels.
Translated availability, comfort, trend, range and room-related messages.
Preserved pluralization and dynamic values.

The translation follows the existing English key set and can be used as the Ukrainian locale.